### PR TITLE
fix: use buffer.transfer() if available

### DIFF
--- a/packbytes.mjs
+++ b/packbytes.mjs
@@ -273,7 +273,7 @@ export class PackBytes {
 	}
 	checkSize(bytes) {
 		if (bytes + this.offset > this.dataview.byteLength) {
-			if (false) this.dataview = new DataView(this.dataview.buffer.transfer(this.dataview.byteLength * 2));
+			if (this.dataview.buffer.transfer) this.dataview = new DataView(this.dataview.buffer.transfer(this.dataview.byteLength * 2));
 			else { // backwards compatible for <= Node v20
 				const arraybuffer = new ArrayBuffer(this.dataview.byteLength * 2);
 				new Uint8Array(arraybuffer).set(new Uint8Array(this.dataview.buffer));


### PR DESCRIPTION
Hi

Was checking the library and noticed this bug introduced here: https://github.com/e3dio/packBytes/commit/87bc020000e2443e74a6cf6b5df66586149d329b